### PR TITLE
Add project docs and templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Django settings
+DEBUG=1
+SECRET_KEY=changeme
+DATABASE_URL=postgres://postgres:postgres@db:5432/maintu
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# OAuth credentials
+ENTRA_CLIENT_ID=
+ENTRA_CLIENT_SECRET=
+ENTRA_TENANT_ID=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear description of what the problem is.
+
+**Describe the solution you'd like**
+A clear description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+
+# Django env
+.env
+!.env.example
+
+# Node
+node_modules/
+
+# Logs and local
+*.log
+
+# Docker
+*.pid
+*.seed
+# ignore compiled
+
+# IDEs
+.vscode/
+.idea/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to mainTU
+
+Thank you for considering a contribution! Please follow these guidelines to keep the project consistent.
+
+## Workflow
+1. **Work on the default branch.** Create focused commits using `git add` and `git commit`.
+2. **Write tests** for any new functionality and ensure the test suite passes.
+3. **Follow the coding rules** outlined in `codexprompt.txt` (type hints, docstrings and security checks).
+4. **Submit a pull request** describing your changes and reference any related issues.
+
+## Code Style
+- Python code should use type hints and Google-style docstrings.
+- React components should be functional and linted with the default React rules.
+
+## Bug Reports and Features
+Please open an issue using the templates in `.github/ISSUE_TEMPLATE`.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
 # mainTU
 
 ## Overview
-This repository demonstrates a simple setup for the **mainTU** project described in
-`codexprompt.txt`. The app uses a Django backend and React frontend, packaged
-with Docker for easy deployment.
+mainTU is a planning tool that forecasts material demand and assigns maintenance tasks. It uses a Django backend and React frontend as described in `codexprompt.txt`.
+
+## Features
+- CSV Uploader and Manager that stores metadata and keeps the five most recent files.
+- Parts forecasting and maintenance tasking modules exposed through a JSON API.
+- Roles for Planner, Supervisor and Admin with local authentication.
+- Responsive React interface using Material UI and D3 heat-map visualisations.
 
 ## Setup
-
-1. **Install Docker & Compose v2**
-   Follow the [Docker Engine installation guide for Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
-2. **Install PostgreSQL 16**
-   Use the [PostgreSQL Ubuntu instructions](https://www.postgresql.org/download/linux/ubuntu/) to add the PGDG repo and install `postgresql-16`.
-3. **Install Node.js 20**
-   Either use nvm or the [NodeSource setup script](https://github.com/nodesource/distributions#debinstall).
-4. **Clone this repository** and create a `.env` file with your database URL and OAuth secrets.
-5. **Build and run** the containers:
+1. **Install prerequisites**: Docker, Compose v2, PostgreSQL 16 and Node.js 20.
+2. **Clone this repository** and copy `.env.example` to `.env` with your credentials.
+3. **Build and run** the containers:
    ```bash
    docker compose build
    docker compose up -d
    ```
-6. **Apply migrations** and create a Django superuser:
+4. **Apply migrations** and create a superuser:
    ```bash
    docker compose exec backend python manage.py migrate
    docker compose exec backend python manage.py createsuperuser
    ```
 
-## Basic Usage
-Visit `http://localhost:8000` after the containers start. Upload the required CSV
-files to generate parts forecasts and maintenance tasking data.
+## Development
+Run tests with:
+```bash
+docker compose exec backend pytest
+# frontend tests
+docker compose exec frontend npm test
+```
+
+## Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and development tips.
+

--- a/codexprompt.txt
+++ b/codexprompt.txt
@@ -62,16 +62,15 @@ You are ChatGPT-Codex, writing production-grade code inside a git-controlled con
 ║ 1. **Base OS**                                                      ║
 ║    sudo apt update && sudo apt upgrade -y                           ║
 ║ 2. **Docker Engine + Compose v2**                                   ║
-║    follow official docs, then `docker compose version` to verify:https://docs.docker.com/engine/install/ubuntu/.║
-║ 3. **PostgreSQL 16** – add PGDG repo & install server/client:https://www.postgresql.org/download/linux/ubuntu/.║
+║    follow official docs: https://docs.docker.com/engine/install/ubuntu/, then run `docker compose version` to verify.║
+║ 3. **PostgreSQL 16** – add PGDG repo & install server/client: https://www.postgresql.org/download/linux/ubuntu/.║
 ║ 4. **Node 20 LTS** – via NodeSource or nvm.                         ║
 ║ 5. **Clone repo** & create `.env` with DB URL, OAuth secrets.       ║
 ║ 6. **Build images** → `docker compose build`, then                  ║
 ║    `docker compose up -d`.                                          ║
 ║ 7. **Run migrations** & create superuser.                           ║
-║ 8. **Reverse-proxy** – Nginx → Gunicorn socket (see DigitalOcean    ║
-║    guide):https://www.digitalocean.com/community/tutorials/how-to-set-up-django-with-postgres-nginx-and-gunicorn-on-ubuntu-22-04.                                           ║
-║ 9. **TLS** – Certbot/Nginx plugin for `maintu.example.com`:https://certbot.eff.org/instructions?ws=nginx&os=ubuntu-22.04.║
+║ 8. **Reverse-proxy** – Nginx → Gunicorn socket (see DigitalOcean guide): https://www.digitalocean.com/community/tutorials/how-to-set-up-django-with-postgres-nginx-and-gunicorn-on-ubuntu-22-04.║
+║ 9. **TLS** – Certbot/Nginx plugin for `maintu.example.com`: https://certbot.eff.org/instructions?ws=nginx&os=ubuntu-22.04.║
 ║10. **Smoke-test** upload CSV, view grid & heat-map, test SSO.       ║
 ╚══════════════════════════════════════════════════════════════════════╝
 
@@ -79,15 +78,14 @@ You are ChatGPT-Codex, writing production-grade code inside a git-controlled con
 ║  D. CODING & DOCUMENTATION RULES                                    ║
 ╠──────────────────────────────────────────────────────────────────────╣
 ║ • Use type-hints (PEP 484) and Google-style docstrings; Sphinx      ║
-║   Napoleon will render them:https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html.                         ║
+║   Napoleon will render them: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html.                         ║
 ║ • Rename uploads via `upload_to` callable per Django pattern        ║
-║   (see StackOverflow example):https://stackoverflow.com/a/15444477.                       ║
-║ • Follow IEEE-830 section headers in comments where helpful:https://en.wikipedia.org/wiki/Software_requirements_specification#IEEE_830-1998.║
-║ • Make UI responsive with MUI breakpoints:https://mui.com/material-ui/customization/breakpoints/ and follow ║
-║   Material Design grid rules:https://material.io/design/layout/responsive-layout-grid.html.                       ║
-║ • Build heat-map with React + D3 tutorial as reference:https://www.pluralsight.com/guides/creating-a-heatmap-with-react-d3.║
-║ • Leverage Entra ID OIDC flow:https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc & Google OAuth 2.0     ║
-║   incremental scopes:https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth.                                  ║
-║ • Ensure colour contrast ≥ 4.5 : 1 per WCAG 2.2:https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html.      ║
-║ • Mitigate OWASP Top-Ten risks:https://owasp.org/www-project-top-ten/.                      ║
+║   (see StackOverflow example): https://stackoverflow.com/a/15444477.                       ║
+║ • Follow IEEE-830 section headers in comments where helpful: https://en.wikipedia.org/wiki/Software_requirements_specification#IEEE_830-1998.║
+║ • Make UI responsive with MUI breakpoints: https://mui.com/material-ui/customization/breakpoints/ and follow ║
+║   Material Design grid rules: https://material.io/design/layout/responsive-layout-grid.html.                       ║
+║ • Build heat-map with React + D3 tutorial as reference: https://www.pluralsight.com/guides/creating-a-heatmap-with-react-d3.║
+║ • Leverage Entra ID OIDC flow: https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc & Google OAuth 2.0 incremental scopes: https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth.║
+║ • Ensure colour contrast ≥ 4.5 : 1 per WCAG 2.2: https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html.      ║
+║ • Mitigate OWASP Top-Ten risks: https://owasp.org/www-project-top-ten/.║
 ╚══════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
## Summary
- expand README with overview, features and development commands
- clean up codexprompt URLs and instructions
- provide `.env.example` and `.gitignore`
- add contribution guide and issue templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688006ecff248328a16f6beec411ef0d