### PR TITLE
Use env variables for settings

### DIFF
--- a/backend/maintu/settings.py
+++ b/backend/maintu/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+import os
+from urllib.parse import urlparse
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,10 +22,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-kl9-w0gvkegrpy7+pk-!o9*kl-f9o2w*6n0%f&u40b-7!yu$*_"
+SECRET_KEY = os.getenv(
+    "SECRET_KEY",
+    "django-insecure-kl9-w0gvkegrpy7+pk-!o9*kl-f9o2w*6n0%f&u40b-7!yu$*_",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DEBUG", "0") == "1"
+
+DATABASE_URL = os.getenv("DATABASE_URL")
 
 ALLOWED_HOSTS = []
 
@@ -77,12 +84,25 @@ WSGI_APPLICATION = "maintu.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+if DATABASE_URL:
+    url = urlparse(DATABASE_URL)
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": url.path.lstrip("/"),
+            "USER": url.username,
+            "PASSWORD": url.password,
+            "HOST": url.hostname,
+            "PORT": str(url.port or ""),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 
 # Password validation

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 Django==4.2.7
 djangorestframework==3.14.0
+gunicorn
+psycopg2-binary


### PR DESCRIPTION
## Summary
- load SECRET_KEY and DEBUG from environment
- configure Postgres via DATABASE_URL
- add gunicorn and psycopg2 dependencies

## Testing
- `python backend/manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68807d9e88c08328898778f426a625ea