### PR TITLE
Add basic React frontend with tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "echo 'Frontend placeholder' && sleep infinity",
-    "test": "echo 'No tests yet'"
+    "start": "react-scripts start",
+    "test": "react-scripts test --env=jsdom"
+  },
+  "dependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "jest": "^27.5.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-scripts": "^5.0.1"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div>
+      <h1>mainTU Frontend</h1>
+      <p>Welcome to the React frontend.</p>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App';
+
+test('renders welcome message', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/welcome to the react frontend/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- create React `App` and entry point
- add Jest test for the `App` component
- update npm scripts for development and testing

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688083ffc4088328b2b23539fc7e242b