### PR TITLE
Load config from environment

### DIFF
--- a/backend/maintu/settings.py
+++ b/backend/maintu/settings.py
@@ -29,10 +29,13 @@ SECRET_KEY = os.getenv(
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "0") == "1"
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgres://postgres:postgres@db:5432/maintu"
+)
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = (
+    os.getenv("ALLOWED_HOSTS", "").split(",") if os.getenv("ALLOWED_HOSTS") else []
+)
 
 
 # Application definition
@@ -84,25 +87,18 @@ WSGI_APPLICATION = "maintu.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-if DATABASE_URL:
-    url = urlparse(DATABASE_URL)
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": url.path.lstrip("/"),
-            "USER": url.username,
-            "PASSWORD": url.password,
-            "HOST": url.hostname,
-            "PORT": str(url.port or ""),
-        }
+url = urlparse(DATABASE_URL)
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": url.path.lstrip("/"),
+        "USER": url.username,
+        "PASSWORD": url.password,
+        "HOST": url.hostname,
+        "PORT": str(url.port or ""),
     }
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
-        }
-    }
+}
 
 
 # Password validation


### PR DESCRIPTION
## Summary
- fetch `DEBUG`, `SECRET_KEY`, `ALLOWED_HOSTS` and `DATABASE_URL` from environment
- default to Postgres using `DATABASE_URL`

## Testing
- `python backend/manage.py check --deploy`

------
https://chatgpt.com/codex/tasks/task_e_688094b162388328980d7c5231c0fa12