### PR TITLE
Add dependencies to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,6 @@ Django==4.2.7
 djangorestframework==3.14.0
 gunicorn
 psycopg2-binary
+
+gunicorn
+psycopg2-binary


### PR DESCRIPTION
## Summary
- append `gunicorn` and `psycopg2-binary` to backend requirements

## Testing
- `docker compose build backend` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688095d2fb308328aed4fa99e1bb596a