### PR TITLE
Add port mappings and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ mainTU is a planning tool that forecasts material demand and assigns maintenance
 - Roles for Planner, Supervisor and Admin with local authentication.
 - Responsive React interface using Material UI and D3 heat-map visualisations.
 - Docker Compose environment to run PostgreSQL, Django and React.
+  The compose file maps the backend to port `8000` and the frontend to port `3000`.
 
 ## Setup
 1. **Install prerequisites**: Docker, Compose v2, PostgreSQL 16 and Node.js 20.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: ./backend
     command: gunicorn maintu.wsgi:application --bind 0.0.0.0:8000
     ports:
-      - "8000:8000"
+      - "8000:8000"  # host:container
     volumes:
       - ./backend:/app
     env_file:
@@ -23,7 +23,7 @@ services:
     build: ./frontend
     command: npm start
     ports:
-      - "3000:3000"
+      - "3000:3000"  # host:container
     volumes:
       - ./frontend:/app
     env_file:


### PR DESCRIPTION
## Summary
- document port mappings in README
- comment port mappings in docker-compose

## Testing
- `pytest -q` *(fails: no tests ran)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68809ab966ac8328ada8613fa1726536