### PR TITLE
Add endpoint smoke tests

### DIFF
--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -18,3 +18,13 @@ class ApiSmokeTests(TestCase):
         response = self.client.get("/api/taskings/")
         self.assertEqual(response.status_code, 200)
 
+
+class EndpointTests(TestCase):
+    """Validate shared API endpoints return HTTP 200."""
+
+    def test_endpoints_return_200(self) -> None:
+        for path in ["/api/parts/", "/api/taskings/"]:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 200)
+

--- a/backend/maintenance/tests.py
+++ b/backend/maintenance/tests.py
@@ -18,3 +18,13 @@ class ApiSmokeTests(TestCase):
         response = self.client.get("/api/taskings/")
         self.assertEqual(response.status_code, 200)
 
+
+class EndpointTests(TestCase):
+    """Validate shared API endpoints return HTTP 200."""
+
+    def test_endpoints_return_200(self) -> None:
+        for path in ["/api/parts/", "/api/taskings/"]:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 200)
+

--- a/backend/parts/tests.py
+++ b/backend/parts/tests.py
@@ -23,6 +23,16 @@ class ApiSmokeTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class EndpointTests(TestCase):
+    """Validate shared API endpoints return HTTP 200."""
+
+    def test_endpoints_return_200(self) -> None:
+        for path in ["/api/parts/", "/api/taskings/"]:
+            with self.subTest(path=path):
+                response = self.client.get(path)
+                self.assertEqual(response.status_code, 200)
+
+
 class CleanupCSVCommandTests(TestCase):
     """Tests for the cleanup_csvs management command."""
 


### PR DESCRIPTION
## Summary
- verify `/api/parts/` and `/api/taskings/` endpoints respond with HTTP 200 for each app
- no new migrations were needed after running `makemigrations`

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6880b06bfbc88328adf2957a75ad0757