### PR TITLE
Add media settings

### DIFF
--- a/backend/maintu/settings.py
+++ b/backend/maintu/settings.py
@@ -145,6 +145,10 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
+# Media files (uploaded by users)
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
 # Custom user model
 AUTH_USER_MODEL = "accounts.User"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "8000:8000"  # host:container
     volumes:
       - ./backend:/app
+      - ./backend/media:/app/media
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
## Summary
- configure MEDIA_URL and MEDIA_ROOT in Django settings
- mount media directory in backend service

## Testing
- `PYTHONPATH=backend DATABASE_URL=sqlite:///:memory: DJANGO_SETTINGS_MODULE=maintu.settings pytest backend/accounts/tests.py backend/parts/tests.py backend/maintenance/tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881de45b7b883288b9f06837e7371c0