### PR TITLE
Add read_only_fields to UploadedCSVSerializer

### DIFF
--- a/backend/parts/serializers.py
+++ b/backend/parts/serializers.py
@@ -5,3 +5,4 @@ class UploadedCSVSerializer(serializers.ModelSerializer):
     class Meta:
         model = UploadedCSV
         fields = ["id", "original_name", "file", "uploaded_at"]
+        read_only_fields = ["original_name", "uploaded_at"]


### PR DESCRIPTION
## Summary
- enhance UploadedCSVSerializer with read-only field settings

## Testing
- `python backend/manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6881de48738083288b425928fe2f230a